### PR TITLE
Make the cmd-line args match cowsay's usage

### DIFF
--- a/pokemonsay.sh
+++ b/pokemonsay.sh
@@ -11,11 +11,13 @@ usage() {
 	echo "      Choose what pokemon will be used by its name."
 	echo "    -f, --file COW_FILE"
 	echo "      Specify which .cow file should be used."
-	echo "    -w, --word-wrap COLUMN"
+	echo "    -W, --word-wrap COLUMN"
 	echo "      Specify roughly where messages should be wrapped."
+	echo "    -n, --no-wrap"
+	echo "      Do not wrap the messages."
 	echo "    -l, --list"
 	echo "      List all the pokémon available."
-	echo "    -n, --no-name"
+	echo "    -N, --no-name"
 	echo "      Do not tell the pokémon name."
 	echo "    -t, --think"
 	echo "      Make the pokémon think the message, instead of saying it."
@@ -62,12 +64,16 @@ case $key in
 		COW_FILE="${1#*=}"
 		shift
 		;;
-	-w|--word-wrap)
+	-W|--word-wrap)
 		WORD_WRAP="$2"
 		shift; shift
 		;;
-	-w=*|--word-wrap=*)
+	-W=*|--word-wrap=*)
 		WORD_WRAP="${1#*=}"
+		shift
+		;;
+	-n|--no-wrap)
+		DISABLE_WRAP="YES"
 		shift
 		;;
 	-l|--list)
@@ -101,8 +107,11 @@ case $key in
 esac
 done
 
-# Define where to wrap the message.
-if [ -n "$WORD_WRAP" ]; then
+# Disable wrapping if the option is set, otherwise
+# define where to wrap the message.
+if [ -n "{DISABLE_WRAP:-}" == "YES" ]; then
+	word_wrap="-n"
+elif [ -n "$WORD_WRAP" ]; then
 	word_wrap="-W $WORD_WRAP"
 fi
 


### PR DESCRIPTION
This adds/changes the cmd args for `pokemonsay` so that they more closely mirror `cowsay`

* changed settings wrapping width with `-W` instead of `-w`.
* implemented missing arg `-n` to disable line wrapping
* Changed existing `-n` to `-N` to avoid conflict